### PR TITLE
Disable WASM SIMD

### DIFF
--- a/src/DevilDaggersInfo.Web.Client/DevilDaggersInfo.Web.Client.csproj
+++ b/src/DevilDaggersInfo.Web.Client/DevilDaggersInfo.Web.Client.csproj
@@ -4,6 +4,9 @@
     <Version>5.7.11.0</Version>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IntermediateOutputPath>obj</IntermediateOutputPath>
+
+    <!--Disable SIMD so the website can run on older hardware.-->
+    <WasmEnableSIMD>false</WasmEnableSIMD>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- [ ] Test JavaScript interop
- [ ] Fix chart hover not working without SIMD (`Microsoft.JSInterop.JSException: The value 'getBoundingClientRect' is not a function.`)